### PR TITLE
split関数の修正。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DEBUGFLAGS = -g -fsanitize=address
 # DEBUGFLAGS = -g -fsanitize=address -fsanitize=undefined -fsanitize=integer
 LEAKSFLAG = -DSERVER_LEAKS
 RM = rm -r -f
-SRCS = Server.cpp ServerSocket.cpp Config.cpp Info.cpp \
+SRCS = Server.cpp ServerSocket.cpp Config.cpp Info.cpp split.cpp \
 	   User.cpp \
 	   Channel.cpp \
 	   Parser.cpp \

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -25,7 +25,6 @@ class Server {
 
 	 int	setFd(int fd);
 	 void	handleServerSocket();
-	 // void	handleStandardInput();
 	 void	handleClientSocket();
 	 void	handleReceivedData(User* user);
 
@@ -45,6 +44,7 @@ class Server {
 	// Bureaucrat::GradeTooHighException::GradeTooHighException(const std::string& msg) : std::out_of_range(msg) {}
 };
 
-void	sendNonBlocking(int fd, const char* buffer, size_t dataSize);
+void						sendNonBlocking(int fd, const char* buffer, size_t dataSize);
+std::vector<std::string>	split(const std::string& message, const std::string delim, User* user);
 
 #endif  // SERVER_HPP

--- a/server/split.cpp
+++ b/server/split.cpp
@@ -1,0 +1,103 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include "../user/User.hpp"
+
+std::vector<std::string>	split(const std::string& message, const std::string delim, User* user) {
+	try {
+		std::vector<std::string>	messages;
+		std::string::size_type		startPos(0);
+
+		while (startPos < message.size()) {
+			std::string::size_type	delimPos = message.find(delim, startPos);
+			if (delimPos == message.npos && startPos < message.size()) {
+				user->setLeftMsg(message.substr(startPos));
+				break;
+			}
+			if (delimPos > startPos) {
+				// TODO(hnoguchi): std::string::substr(); throw exception std::out_of_range();
+				std::string	buf = message.substr(startPos, delimPos - startPos);
+				messages.push_back(buf);
+			}
+			startPos = delimPos + delim.size();
+		}
+		return (messages);
+	} catch (std::exception& e) {
+		throw;
+	}
+}
+
+#ifdef UTEST_SPLIT
+#include "../color.hpp"
+
+void	printMsg(const std::string& color, const std::string& msg) {
+	for (size_t i = 0; i < msg.size(); i++) {
+		if (msg[i] == '\r') {
+			std::cout << RED << "\\r" << END << std::flush;
+		} else if (msg[i] == '\n') {
+			std::cout << RED << "\\n" << END << std::flush;
+		} else if (!color.empty()) {
+			std::cout << color << msg[i] << END << std::flush;
+		} else {
+			std::cout << msg[i] << std::flush;
+		}
+	}
+}
+
+void	printTestMsg(const std::string& msg) {
+	std::cout << "testMsg_____________________" << std::endl;
+	std::cout << "[" << std::flush;
+	printMsg(GREEN, msg);
+	std::cout << "]" << std::endl;
+	// std::cout << std::endl;
+	// std::cout << "----------------------------" << std::endl;
+}
+
+void	printSplited(const std::vector<std::string>& splited) {
+	for (size_t i = 0; i < splited.size(); i++) {
+		std::cout << "[" << std::flush;
+		printMsg("", splited[i]);
+		std::cout << "]" << std::endl;
+	}
+	// std::cout << std::endl;
+}
+
+int main() {
+	std::string testList[] = {
+		"COMMAND param\r\n",
+		"COMMAND param\r\nCOMMAND param\r\n",
+		"COMMAND param\r\nCOMMAND param\r\nCOMMAND param\r\n",
+		"COMMAND param",
+		"COMMAND param\r\nCOMMAND param",
+		"COMMAND param\r\nCOMMAND param\r\nCOMMAND param",
+		"COMMAND param\r",
+		"COMMAND param\r\nCOMMAND param\r",
+		"COMMAND param\r\nCOMMAND param\r\nCOMMAND param\r",
+		"COMMAND param\n",
+		"COMMAND param\r\nCOMMAND param\n",
+		"COMMAND param\r\nCOMMAND param\r\nCOMMAND param\n",
+		"COMMAND param\r\n\r",
+		"COMMAND param\r\nCOMMAND param\r\n\r",
+		"COMMAND param\r\nCOMMAND param\r\n\rCOMMAND param\r\n",
+		"COMMAND param\r\n\r\nCOMMAND param\r\n",
+	};
+
+	std::string next("");
+	for (size_t i = 0; i < sizeof(testList) / sizeof(testList[0]); i++) {
+		printTestMsg(testList[i]);
+		testList[i] = next + testList[i];
+		next = "";
+		printMsg(GREEN, testList[i]);
+		std::cout << std::endl;
+		std::vector<std::string>	msgs = split(testList[i], "\r\n", &next);
+		printSplited(msgs);
+		if (!next.empty()) {
+			std::cout << "next: [" << std::flush;
+			printMsg("", next);
+			std::cout << "]" << std::endl;
+		}
+		std::cout << std::endl;
+	}
+}
+
+#endif  // UTEST_SPLIT

--- a/user/User.cpp
+++ b/user/User.cpp
@@ -82,6 +82,10 @@ void	User::setMode(kUserMode mode) {
 	this->modes_ |= mode;
 }
 
+void	User::setLeftMsg(const std::string& msg) {
+	this->leftMsg_ = msg;
+}
+
 void	User::unsetMode(kUserMode mode) {
 	this->modes_ ^= (this->modes_ & mode);
 }
@@ -129,6 +133,10 @@ unsigned int	User::getRegistered() const {
 
 unsigned int	User::getModes() const {
 	return (this->modes_);
+}
+
+const std::string&	User::getLeftMsg() const {
+	return (this->leftMsg_);
 }
 
 void	User::disconnect() {

--- a/user/User.hpp
+++ b/user/User.hpp
@@ -32,6 +32,7 @@ class User {
 	 int*			fd_;
 	 unsigned int	registered_;
 	 unsigned int	modes_;
+	 std::string	leftMsg_;
 
  public:
 	 explicit User(int* fd = NULL);
@@ -51,6 +52,7 @@ class User {
 	 void	setFd(int* fd);
 	 void	setRegistered(kExecCommand flag);
 	 void	setMode(kUserMode mode);
+	 void	setLeftMsg(const std::string &msg);
 	 void	unsetMode(kUserMode mode);
 	 // GETTERS
 	 const std::string&	getNickName() const;
@@ -64,6 +66,7 @@ class User {
 	 int				getFd() const;
 	 unsigned int		getRegistered() const;
 	 unsigned int		getModes() const;
+	 const std::string&	getLeftMsg() const;
 
 	 void				disconnect();
 	 void				resetData();


### PR DESCRIPTION
"\r\n\r\n"のように、デリミタが繰り返される文字列が来た場合、空文字列を生成するバグを修正。
サイズが０の時は、文字列を生成しないようにする。
"message", "message\r"のようにメッセージが途切れている場合、破棄していたバグを修正。
std::string User.leftMsg_;メンバ変数を用意し、そこに保存する処理に変更。
次のメッセージを処理する際に、先頭へ繋げる。