### PR TITLE
リファクタリング（Parserクラス）。Parser::tokenize();の修正。

### DIFF
--- a/sand_box/Parser/Makefile
+++ b/sand_box/Parser/Makefile
@@ -56,8 +56,12 @@ leaks:
 	leaks -q --atExit -- ./$(NAME)
 
 .PHONY: tokenize
-tokenize: CXXFLAGS += -DUTEST_TOKENIZE
-tokenize: re
+tokenize: CXXFLAGS = $(DEBUGFLAGS) -DUTEST_TOKENIZE
+tokenize: $(OBJS_DIR)
+tokenize: $(OBJS)
+tokenize:
+	$(CXX) $(DEBUGFLAGS) -o $(NAME) $(OBJS)
+	./$(NAME)
 
 .PHONY: validparam
 validparam:


### PR DESCRIPTION
"COMMAND   param"といったような、スペースが連続した文字列の場合、空文字列のトークンを生成していたバグを修正。
値が空文字列の時、トークンを生成せず、無視する仕様にする。
"     COMMAND"といったような、先頭にスペースが連続した文字列の場合、空文字列のトークンを生成していたバグを修正。
はじめに、スペースがなくなるまで、文字列を進める処理を追加する。