### PR TITLE
挙動確認で見つけたバグを修正。

### DIFF
--- a/execute/channel_operations/cmdInvite.cpp
+++ b/execute/channel_operations/cmdInvite.cpp
@@ -38,7 +38,7 @@ void	Execute::cmdInvite(User* user, const ParsedMsg& parsedMsg, Info* info) {
 		}
 		// UserがChannel Operatorか確認
 		if (!(*channelIt)->isOperator(user->getNickName())) {
-			reply += Reply::errChanOprivsNeeded(kERR_CHANOPRIVSNEEDED, user->getPrefixName(), user->getNickName(), parsedMsg.getParams()[1].getValue());
+			reply += Reply::errChanOprivsNeeded(kERR_CHANOPRIVSNEEDED, user->getPrefixName(), parsedMsg.getParams()[1].getValue());
 			Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
 			return;
 		}
@@ -61,7 +61,9 @@ void	Execute::cmdInvite(User* user, const ParsedMsg& parsedMsg, Info* info) {
 			Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
 			return;
 		}
-		(*channelIt)->pushBackInvited(*info->findUser((*targetUserIt)->getNickName()));
+		if (!(*channelIt)->isInvited(*info->findUser((*targetUserIt)->getNickName()))) {
+			(*channelIt)->pushBackInvited(*info->findUser((*targetUserIt)->getNickName()));
+		}
 		std::string	msg = ":" + user->getPrefixName() + " INVITE " + (*targetUserIt)->getNickName() + " " + (*channelIt)->getName() + Reply::getDelimiter();
 		Server::sendNonBlocking((*targetUserIt)->getFd(), msg.c_str(), msg.size());
 		Server::sendNonBlocking(user->getFd(), msg.c_str(), msg.size());

--- a/execute/channel_operations/cmdJoin.cpp
+++ b/execute/channel_operations/cmdJoin.cpp
@@ -43,13 +43,6 @@ void	Execute::cmdJoin(User* user, const ParsedMsg& parsedMsg, Info* info) {
 		std::vector<Channel*>::iterator	channelIt = info->findChannel(parsedMsg.getParams()[0].getValue());
 		// <channel>が存在する場合
 		if (channelIt != info->getChannels().end()) {
-			if ((*channelIt)->getModes() & kLimit) {
-				if ((*channelIt)->getMembers().size() >= static_cast<unsigned long>((*channelIt)->getLimit())) {
-					reply += Reply::errChannelIsFull(kERR_CHANNELISFULL, user->getPrefixName(), (*channelIt)->getName());
-					Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
-					return;
-				}
-			}
 			if ((*channelIt)->getModes() & kInviteOnly) {
 				if (!(*channelIt)->isInvited(user->getNickName())) {
 					reply += Reply::errInviteOnlyChan(kERR_INVITEONLYCHAN, user->getPrefixName(), (*channelIt)->getName());
@@ -58,8 +51,7 @@ void	Execute::cmdJoin(User* user, const ParsedMsg& parsedMsg, Info* info) {
 				}
 				(*channelIt)->eraseInvited(*info->findUser(user->getNickName()));
 			}
-			if ((*channelIt)->getModes() & kKey) {
-					// std::cerr << "[" << parsedMsg.getParams()[1].getValue() <<"] | [" << (*channelIt)->getKey() << "]" << std::endl;
+			if ((*channelIt)->getModes() & kKeySet) {
 				if (parsedMsg.getParams().size() < 2) {
 					reply += Reply::errBadChannelKey(kERR_BADCHANNELKEY, user->getPrefixName(), (*channelIt)->getName());
 					Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
@@ -67,6 +59,13 @@ void	Execute::cmdJoin(User* user, const ParsedMsg& parsedMsg, Info* info) {
 				}
 				if (parsedMsg.getParams()[1].getValue() != (*channelIt)->getKey()) {
 					reply += Reply::errBadChannelKey(kERR_BADCHANNELKEY, user->getPrefixName(), (*channelIt)->getName());
+					Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
+					return;
+				}
+			}
+			if ((*channelIt)->getModes() & kLimit) {
+				if ((*channelIt)->getMembers().size() >= static_cast<unsigned long>((*channelIt)->getLimit())) {
+					reply += Reply::errChannelIsFull(kERR_CHANNELISFULL, user->getPrefixName(), (*channelIt)->getName());
 					Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
 					return;
 				}

--- a/execute/channel_operations/cmdKick.cpp
+++ b/execute/channel_operations/cmdKick.cpp
@@ -46,7 +46,7 @@ void	Execute::cmdKick(User* user, const ParsedMsg& parsedMsg, Info* info) {
 		}
 		// userがchannel operatorか確認
 		if (!(*channelIt)->isOperator(user->getNickName())) {
-			reply += Reply::errChanOprivsNeeded(kERR_CHANOPRIVSNEEDED, user->getPrefixName(), user->getNickName(), parsedMsg.getParams()[0].getValue());
+			reply += Reply::errChanOprivsNeeded(kERR_CHANOPRIVSNEEDED, user->getPrefixName(), parsedMsg.getParams()[0].getValue());
 			Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
 			return;
 		}

--- a/execute/channel_operations/cmdTopic.cpp
+++ b/execute/channel_operations/cmdTopic.cpp
@@ -38,12 +38,6 @@ void	Execute::cmdTopic(User* user, const ParsedMsg& parsedMsg, Info* info) {
 			Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
 			return;
 		}
-		// userがchannel operatorか確認
-		if (!(*channelIt)->isOperator(user->getNickName())) {
-			reply += Reply::errChanOprivsNeeded(kERR_CHANOPRIVSNEEDED, user->getPrefixName(), user->getNickName(), parsedMsg.getParams()[0].getValue());
-			Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
-			return;
-		}
 		// <topic>がない場合、RPL_(NO)TOPICを返す
 		if (parsedMsg.getParams().size() == 1) {
 			if ((*channelIt)->getTopic().empty()) {
@@ -63,14 +57,17 @@ void	Execute::cmdTopic(User* user, const ParsedMsg& parsedMsg, Info* info) {
 		}
 		// <channel>にt modeが設定されているか確認
 		if ((*channelIt)->getModes() & kRestrictTopicSetting) {
-			reply += Reply::errNoChanModes(kERR_NOCHANMODES, user->getPrefixName(), user->getNickName(), parsedMsg.getParams()[0].getValue());
-			Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
-			return;
+			// userがchannel operatorか確認
+			if (!(*channelIt)->isOperator(user)) {
+				reply += Reply::errChanOprivsNeeded(kERR_CHANOPRIVSNEEDED, user->getPrefixName(), parsedMsg.getParams()[0].getValue());
+				Server::sendNonBlocking(user->getFd(), reply.c_str(), reply.size());
+				return;
+			}
 		}
 		// topicの設定を実行
 		(*channelIt)->setTopic(parsedMsg.getParams()[1].getValue());
 		// <channel>のメンバにtopicの変更を通知
-		std::string	msg = ":" + user->getNickName() + " TOPIC " + (*channelIt)->getName() + " :" + (*channelIt)->getTopic() + Reply::getDelimiter();
+		std::string	msg = ":" + user->getPrefixName() + " TOPIC " + (*channelIt)->getName() + " " + (*channelIt)->getTopic() + Reply::getDelimiter();
 		for (std::vector<User*>::const_iterator	memberIt = (*channelIt)->getMembers().begin(); memberIt != (*channelIt)->getMembers().end(); memberIt++) {
 			Server::sendNonBlocking((*memberIt)->getFd(), msg.c_str(), msg.size());
 		}

--- a/parser/Parser.cpp
+++ b/parser/Parser.cpp
@@ -400,6 +400,12 @@ int	Parser::validTopic(const User& user, const std::vector<Token>& tokens, const
 		}
 		this->parsed_.setParam(tokens[1].getType(), kChannel, this->toLowerString(tokens[1].getValue()));
 		if (tokens.size() == 3) {
+			ValidParam	validParam;
+			if (validParam.isTopic(tokens[2].getValue()) == false) {
+				reply += Reply::errNoTextToSend(kERR_NOTEXTTOSEND, user.getPrefixName());
+				Server::sendNonBlocking(user.getFd(), reply.c_str(), reply.size());
+				return (-1);
+			}
 			this->parsed_.setParam(tokens[2].getType(), kTopic, tokens[2].getValue());
 		}
 		return (0);

--- a/parser/ValidParam.cpp
+++ b/parser/ValidParam.cpp
@@ -175,11 +175,11 @@ bool	ValidParam::isChannel(const std::string& channel) {
 // chanstring	=	%x01-07 / %x08-09 / %x0B-0C / %x0E-1F / %x21-2B / %x2D-39 / %x3B-FF
 // ; any octet except NUL, BELL, CR, LF, " ", "," and ":"
 bool	ValidParam::isMessage(const std::string& message) {
-	if (message.size() > 510) {
+	if (message.size() > 400) {
 		return (false);
 	}
 	for (size_t i = 0; i < message.size(); i++) {
-		if (!this->isChanStringChar(message[i])) {
+		if (!this->isChanStringChar(message[i]) && message[i] != ' ') {
 			return (false);
 		}
 	}
@@ -192,8 +192,8 @@ bool	ValidParam::isTopic(const std::string& topic) {
 	if (topic.size() > 30) {
 		return (false);
 	}
-	for (size_t i = 0; i < topic.size(); i++) {
-		if (!this->isChanStringChar(topic[i])) {
+	for (size_t i = 1; i < topic.size(); i++) {
+		if (!this->isChanStringChar(topic[i]) && topic[i] != ' ') {
 			return (false);
 		}
 	}

--- a/reply/Reply.cpp
+++ b/reply/Reply.cpp
@@ -111,13 +111,30 @@ std::string	Reply::rplUModeIs(int num, const std::string& toName, const User& us
 }
 
 // 324	RPL_CHANNELMODEIS	<channel> <mode> <mode params>
-std::string	Reply::rplChannelModeIs(int num, const std::string& toName, const std::string& channel, const char mode, const std::string& param) {
+std::string	Reply::rplChannelModeIs(int num, const std::string& toName, const Channel& channel) {
 	try {
 		std::string	message = Reply::rplCmdToName(num, toName);
 
-		message += channel + " " + mode;
-		if (!param.empty()) {
-			message += " " + param;
+		message += channel.getName() + " +";
+		if (channel.getModes() & kInviteOnly) {
+			message += "i";
+		}
+		if (channel.getModes() & kKeySet) {
+			message += "k";
+		}
+		if (channel.getModes() & kLimit) {
+			message += "l";
+		}
+		if (channel.getModes() & kRestrictTopicSetting) {
+			message += "t";
+		}
+		if (channel.getModes() & kKeySet) {
+			message += " " + channel.getKey();
+		}
+		if (channel.getModes() & kLimit) {
+			std::stringstream	ss;
+			ss << channel.getLimit();
+			message += " " + ss.str();
 		}
 		message += Reply::delimiter_;
 		return (message);
@@ -146,7 +163,7 @@ std::string	Reply::rplTopic(int num, const std::string& toName, const std::strin
 		// std::string	message = "332 " + channel + " :" + topic;
 		std::string	message = Reply::rplCmdToName(num, toName);
 
-		message += channel + " :" + topic;
+		message += channel + " " + topic;
 		message += Reply::delimiter_;
 		return (message);
 	} catch (const std::exception& e) {
@@ -530,11 +547,11 @@ std::string	Reply::errNoChanModes(int num, const std::string& toName, const std:
 	}
 }
 
-std::string	Reply::errChanOprivsNeeded(int num, const std::string& toName, const std::string& nickName, const std::string& channel) {
+std::string	Reply::errChanOprivsNeeded(int num, const std::string& toName, const std::string& channel) {
 	try {
 		std::string	message = Reply::rplCmdToName(num, toName);
 
-		message += nickName + " " + channel + " :You're not channel operator";
+		message += channel + " :You're not channel operator";
 		message += Reply::delimiter_;
 		return (message);
 	} catch (const std::exception& e) {

--- a/reply/Reply.hpp
+++ b/reply/Reply.hpp
@@ -92,7 +92,7 @@ class Reply {
 	 static std::string	rplWelcome(const Info& info, const User& user);
 
 	 static std::string	rplUModeIs(int num, const std::string& toName, const User& user);
-	 static std::string	rplChannelModeIs(int num, const std::string& toName, const std::string& channel, const char mode, const std::string& param);
+	 static std::string	rplChannelModeIs(int num, const std::string& toName, const Channel& channel);
 	 static std::string	rplNoTopic(int num, const std::string& toName, const std::string& channel);
 	 static std::string	rplTopic(int num, const std::string& toName, const std::string& channel, const std::string& topic);
 	 static std::string	rplInviting(int num, const std::string& toName, const std::string& channel, const std::string& nickName);
@@ -123,7 +123,7 @@ class Reply {
 	 static std::string	errInviteOnlyChan(int num, const std::string& toName, const std::string& channel);
 	 static std::string	errBadChannelKey(int num, const std::string& toName, const std::string& channel);
 	 static std::string	errNoChanModes(int num, const std::string& toName, const std::string& nickName, const std::string& channel);
-	 static std::string	errChanOprivsNeeded(int num, const std::string& toName, const std::string& nickName, const std::string& channel);
+	 static std::string	errChanOprivsNeeded(int num, const std::string& toName, const std::string& channel);
 	 static std::string	errRestricted(int num, const std::string& toName);
 	 static std::string	errUModeUnknownFlag(int num, const std::string& toName);
 	 static std::string	errUsersDontMatch(int num, const std::string& toName);


### PR DESCRIPTION
同じuserに複数回INVITEコマンドを実行したとき、Channel::invited_;に複数回追加されていたバグを修正。
INVITEコマンドの実行メッセージは送信するが、Channel::invited_;には、１度だけ追加する仕様に変更する。